### PR TITLE
Add PlayerHealth script and related folders

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Assets/Development/General Managers.meta
+++ b/Assets/Development/General Managers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 65bbd209b98d49d408ce4414febdaf9f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/General Scripts.meta
+++ b/Assets/Development/General Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d10f93816ca42c7459a7434cd336e615
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Player.meta
+++ b/Assets/Development/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d9f3f218c7554d4a93104a6c87d9d89
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Player/Health, Death, Respawning.meta
+++ b/Assets/Development/Player/Health, Death, Respawning.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9fb7f4c4cb5a65845b219bfef574a3fa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Player/Health, Death, Respawning/PlayerHealth.cs
+++ b/Assets/Development/Player/Health, Death, Respawning/PlayerHealth.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class PlayerHealth : MonoBehaviour
+{
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Development/Player/Health, Death, Respawning/PlayerHealth.cs.meta
+++ b/Assets/Development/Player/Health, Death, Respawning/PlayerHealth.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c892f505f9d78844a437dbf7902df8f


### PR DESCRIPTION
Created initial folder structure for player health, death, and respawning logic. Added a placeholder PlayerHealth MonoBehaviour script and associated Unity .meta files.