### PR TITLE
Jacob bug fix

### DIFF
--- a/Assets/Development/UISystems/Settings/UI_VideoOptions.cs
+++ b/Assets/Development/UISystems/Settings/UI_VideoOptions.cs
@@ -167,7 +167,7 @@ public class UI_VideoOptions : UI_SettingsMenu
 
         for (int i = 0; i < resolutions.Length; i++)
         {
-            string option = resolutions[i].width + " x " + resolutions[i].height;
+            string option = resolutions[i].width + " x " + resolutions[i].height + " @ " + resolutions[i].refreshRate + "hz" ; ;
             options.Add(option);
             if (savedIndex == resolBase &&
                 resolutions[i].width == Screen.currentResolution.width &&

--- a/Assets/Development/UISystems/Settings/UI_VideoOptions.cs
+++ b/Assets/Development/UISystems/Settings/UI_VideoOptions.cs
@@ -185,7 +185,7 @@ public class UI_VideoOptions : UI_SettingsMenu
         resolDropdown.AddOptions(options);
         resolDropdown.SetValueWithoutNotify(currentIndex);
         resolDropdown.RefreshShownValue();
-        SetResolution(currentIndex, isFullScreen);
+      //  SetResolution(currentIndex, isFullScreen);
         resolDropdown.onValueChanged.AddListener(OnResolutionChanged);
 
     }


### PR DESCRIPTION
two, one-line changes to the video options menu, targeting the forced resolution refresh issue, and lessening the issue of duplicate resolution options in the drop down by showing the refresh rate options

@Baronadev there's still a slight issue, even with this fix, in the visual settings menu (at least when I tested it in a dev build). I have a suspicion it's tied to the fullscreen/windowed options, but not fully certain. I have not added the list reversal commit because I'm tired and forgor how arrays work rn