### PR TITLE
Post-TFSFest Updates, TI, MainMenu, Humans, RaceFail

### DIFF
--- a/Assets/Development/Enemies/PatrolChaseThrowEnemy/EnemyPatrol.cs
+++ b/Assets/Development/Enemies/PatrolChaseThrowEnemy/EnemyPatrol.cs
@@ -406,7 +406,7 @@ public class EnemyPatrol : EnemyBaseComponent
 
     protected async void ThrowObject()
     {
-        if (!isHoldingItem && isKicking || isThrowing || !canSeePlayer) return;
+        if (isHoldingItem || isKicking || isThrowing || !canSeePlayer) return;
         isThrowing = true;
         StopMove();
         Vector3 facingDir = (player.transform.position - transform.position).normalized;
@@ -542,6 +542,7 @@ public class EnemyPatrol : EnemyBaseComponent
         spawned.GetComponent<Rigidbody>().isKinematic = true;
         spawned.transform.SetParent(objectSpawnPoint, false);
         spawned.transform.position = objectSpawnPoint.transform.position;
+        spawned.GetComponent<ParticleSystem>().Stop();
         isHoldingItem = true;
 
     }

--- a/Assets/Development/Enemies/PatrolChaseThrowEnemy/HumanThrownObject.prefab
+++ b/Assets/Development/Enemies/PatrolChaseThrowEnemy/HumanThrownObject.prefab
@@ -58,7 +58,7 @@ PrefabInstance:
       objectReference: {fileID: 952658372932632003, guid: 7bb59570f204a9d409b21f104e33eb96, type: 3}
     - target: {fileID: 919132149155446097, guid: 5e6c02eb32d2270488ca9d17ac665b3c, type: 3}
       propertyPath: m_Name
-      value: SM_Coffee
+      value: HumanThrownObject
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 5e6c02eb32d2270488ca9d17ac665b3c, type: 3}
       propertyPath: m_Layer
@@ -167,4 +167,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a85bbc18634343848b3a1f45c6a79d06, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::ThrownObject
-  damage: 1
+  damage: 5

--- a/Assets/Development/Player/Movement/PlayerFlightMovement.cs
+++ b/Assets/Development/Player/Movement/PlayerFlightMovement.cs
@@ -308,6 +308,7 @@ public class PlayerFlightMovement : MonoBehaviour
     {
         if (isFlying && !isDiving && !isStalling)
         {
+            playerStamina.UseStamina(1);
             playerBody.linearVelocity = new Vector3(playerBody.linearVelocity.x, flapUpVelocity, playerBody.linearVelocity.z);
             flapUp = true;
             await Task.Delay(500);

--- a/Assets/Development/Player/Poop Combat/PoopSystem.cs
+++ b/Assets/Development/Player/Poop Combat/PoopSystem.cs
@@ -4,8 +4,8 @@ using NUnit.Framework;
 
 public class PoopSystem : MonoBehaviour
 {
-    [Header ("Poop Settings")]
-    [SerializeField] private int maxPoop = 5;
+    [Header("Poop Settings")]
+    [SerializeField] private int maxPoop = 10;
     [SerializeField] private float poopCooldown = 2.0f;
     [SerializeField] private int poopBonus = 0;
     [SerializeField] private PlayerAccessoryComponent accessoryComponent;
@@ -51,7 +51,7 @@ public class PoopSystem : MonoBehaviour
         {
             updateItemsTimer -= Time.deltaTime;
         }
-        else GetCurrentAccessories() ;
+        else GetCurrentAccessories();
     }
 
     public void AddMaxPoop(int value)
@@ -66,14 +66,14 @@ public class PoopSystem : MonoBehaviour
 
     public bool TryPoop()
     {
-        if (!CanPoop) return false;
-
+        if (!CanPoop || currentPoop<=0) return false;
+        currentPoop--;
         cooldownTimer = poopCooldown;
         return true;
     }
 
     //Logic to restore poop, ensure does not go past max poop count
-    private void RestorePoop(int amount) => currentPoop = Mathf.Min(currentPoop + amount, maxPoop);
+    private void RestorePoop(int amount) => currentPoop = (int)Mathf.Lerp(currentPoop,Mathf.Min(currentPoop + amount, maxPoop),Time.deltaTime);
     //logic to increase the maximum poop count
     private void IncreaseMaxPoop(int amount) => maxPoop += amount;
 

--- a/Assets/Development/Player/Stamina/StaminaSystem.cs
+++ b/Assets/Development/Player/Stamina/StaminaSystem.cs
@@ -12,7 +12,7 @@ public class StaminaSystem : MonoBehaviour
 
     public void SetMaxStamina(float stamina)
     {
-
+        MaxStamina += stamina;
     }
 
     public float GetMaxStamina() {  return MaxStamina; }

--- a/Assets/Development/Race System/Checkpoint/RaceCheckpoint.cs
+++ b/Assets/Development/Race System/Checkpoint/RaceCheckpoint.cs
@@ -30,6 +30,7 @@ public class RaceCheckpoint : MonoBehaviour
         if (raceBase != null && raceBase.checkpointIndex == checkpointNumber)
         {
             raceBase.UpdateCheckpoints(checkpointNumber);
+            raceBase.UpdatePlayerArrow(checkpointNumber);
             checkpointParticle.Play();
             GetComponent<MeshRenderer>().enabled = false;
             

--- a/Assets/Development/Race System/RaceBase.cs
+++ b/Assets/Development/Race System/RaceBase.cs
@@ -8,6 +8,7 @@ using Unity.Cinemachine;
 public class RaceBase : MonoBehaviour
 {
     private GameObject playerRef => GetPlayer();
+    PlayerNavArrow navArrow;
     [SerializeField] private UI_CanvasController canvasController;
     public RaceData raceData => GetRaceData(currentRaceGiver.raceData);
     [SerializeField] private RaceCheckpoint checkpointPrefab;
@@ -43,6 +44,7 @@ public class RaceBase : MonoBehaviour
 
     private void Start()
     {
+        navArrow = playerRef.GetComponent<PlayerNavArrow>();
         if (activeCheckpoints.Count > 0)
             lastCheckpoint = activeCheckpoints[activeCheckpoints.Count - 1];
     }
@@ -87,6 +89,21 @@ public class RaceBase : MonoBehaviour
         {
             currentTime -= Time.deltaTime;
             if (currentTime <= 0 && !raceFailed) { raceFailed = true; RaceFailed(); }
+        }
+    }
+
+    public void UpdatePlayerArrow(int index)
+    {
+        if(index == 0)
+        {
+            navArrow.EnablePointerArrow(activeCheckpoints[0].gameObject);
+            return;
+        }
+        else
+        {
+            var next = activeCheckpoints[index + 1].gameObject;
+            navArrow.EnablePointerArrow(next);
+            return;
         }
     }
 
@@ -145,6 +162,7 @@ public class RaceBase : MonoBehaviour
             racer.StartMoving();
         }
         StartPlayerMove();
+        UpdatePlayerArrow(0);
     }
 
     private void SpawnCheckpoints()
@@ -182,15 +200,17 @@ public class RaceBase : MonoBehaviour
         raceStarted = false;
         GetRaceResults();
         DestroyRacers();
+        navArrow.DestroyArrow();
         canvasController.OpenRaceRewards();
         DestroyCheckpoints();
     }
 
     private void RaceFailed()
     {
-        StopPlayerMove();
         raceStarted = false;
+        navArrow.DestroyArrow();
         canvasController.OpenRaceFail();
+        DestroyCheckpoints();
     }
 
 
@@ -274,7 +294,9 @@ public class RaceBase : MonoBehaviour
     {
         countdown = 5;
         countdownComplete = false;
-        timerStarted = false;
+        raceTimer = raceData.raceTime;
+        currentTime = raceTimer;
+        timerStarted = true;
         DestroyRacers();
         raceFailed = false;
         Debug.Log("ResetCalled");

--- a/Assets/Development/Race System/UI/UI_RaceFail.cs
+++ b/Assets/Development/Race System/UI/UI_RaceFail.cs
@@ -28,7 +28,7 @@ public class UI_RaceFail : MonoBehaviour
     }
     private void GetRequiredTime()
     {
-        raceRequiredTime.SetText(race.raceData.raceTime.ToString());
+        //raceRequiredTime.SetText(race.raceData.raceTime.ToString());
     }
 
     private void GetRaceInfo()

--- a/Assets/Scenes/LEVELS/MainMenu.unity
+++ b/Assets/Scenes/LEVELS/MainMenu.unity
@@ -6110,9 +6110,25 @@ PrefabInstance:
       propertyPath: jumpHeight
       value: 175
       objectReference: {fileID: 0}
+    - target: {fileID: 5360852943576176621, guid: b0eda1aad6587d3438aa95f0a831a8af, type: 3}
+      propertyPath: counterMovement
+      value: 0.4
+      objectReference: {fileID: 0}
     - target: {fileID: 5691531790606118220, guid: b0eda1aad6587d3438aa95f0a831a8af, type: 3}
       propertyPath: m_Enabled
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5691531790606118220, guid: b0eda1aad6587d3438aa95f0a831a8af, type: 3}
+      propertyPath: stallHeight
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5691531790606118220, guid: b0eda1aad6587d3438aa95f0a831a8af, type: 3}
+      propertyPath: flapUpHeight
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5691531790606118220, guid: b0eda1aad6587d3438aa95f0a831a8af, type: 3}
+      propertyPath: glideDownSpeed
+      value: 400
       objectReference: {fileID: 0}
     - target: {fileID: 5691531790606118220, guid: b0eda1aad6587d3438aa95f0a831a8af, type: 3}
       propertyPath: propLayer.m_Bits
@@ -6121,6 +6137,10 @@ PrefabInstance:
     - target: {fileID: 5691531790606118220, guid: b0eda1aad6587d3438aa95f0a831a8af, type: 3}
       propertyPath: counterVelocityRate
       value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6730209831753822934, guid: b0eda1aad6587d3438aa95f0a831a8af, type: 3}
+      propertyPath: MaxStamina
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 7158780317548020067, guid: b0eda1aad6587d3438aa95f0a831a8af, type: 3}
       propertyPath: m_ExcludeLayers.m_Bits


### PR DESCRIPTION
-Increase countermove for grounded to 0.4 to negate sliding -Decreased flap height and stall height to 0.4 to decrease flight height 
-Fixed health, stam, poop usages
-Fixed race fail locking input
-Added nav arrow to races to show direction
-Fixed human pathing in tut
-Remove held object artifacts ( deactivate consumable vfx on instantiate) 
-Increased human thrown object damage to 5
-Removed visual cones from tut quest
-Updates to TI and MainMenu